### PR TITLE
Add UCSF base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM moodlehq/moodle-php-apache:7.2
+
+COPY . /var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "2"
+services:
+  webserver:
+    build: ./
+    environment:
+      MOODLE_DOCKER_DBTYPE: mariadb
+      MOODLE_DOCKER_DBNAME: moodle
+      MOODLE_DOCKER_DBUSER: moodle
+      MOODLE_DOCKER_DBPASS: "m@0dl3ing"
+    ports:
+            - "8000:80"
+    volumes:
+        - ./:/var/www/html:delegated
+  db:
+    image: mariadb:10.4
+    environment:
+      MYSQL_USER: moodle
+      MYSQL_PASSWORD: "m@0dl3ing"
+      MYSQL_DATABASE: moodle
+      MYSQL_RANDOM_ROOT_PASSWORD: "true"


### PR DESCRIPTION
Creates a base `Dockerfile` which will ship our code and plugins as well as a a `docker-composer.yml` file which we can use in development.

Work in progress todo:
- [ ] Don't use the moodlehq image, it isn't suitable for production
- [ ] Add configuration files so we don't have to do the setup process each time
- [ ] Figure out what goes where (is it secure to put the whole thing in `/var/www/html`?