### PR TITLE
updates External Task Monitor tool plugin to version 2024061000

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "admin/tool/externaltaskmonitor"]
 	path = admin/tool/externaltaskmonitor
 	url = https://github.com/ucsf-education/tool_externaltaskmonitor
-	branch = MOODLE_403_DEVEL
+	branch = MOODLE_403_STABLE
 [submodule "admin/tool/ilioscategoryassignment"]
 	path = admin/tool/ilioscategoryassignment
 	url = https://github.com/ilios/tool_ilioscategoryassignment
@@ -152,10 +152,6 @@
 [submodule "theme/ucsf"]
 	path = theme/ucsf
 	url = https://github.com/ucsf-education/moodle-theme-ucsf
-	branch = MOODLE_403_DEVEL
-[submodule "admin/tool/externaltaskmonitor"]
-	path = admin/tool/externaltaskmonitor
-	url = https://github.com/ucsf-education/tool_externaltaskmonitor
 	branch = MOODLE_403_DEVEL
 [submodule "admin/tool/ilioscategoryassignment"]
 	path = admin/tool/ilioscategoryassignment


### PR DESCRIPTION
## Changelog

- start testing this plugin with Moodle 4.4

## Full Diff

https://github.com/ucsf-education/tool_externaltaskmonitor/compare/751f82e996ed46da8ae74f8bf24ef60edca4ae46...68d683f504a31ef09f91eaa5979ab86527c4641e