### PR TITLE
Add cwarwicker/moodle-tool_ribbons plugin with moodle_4.4 tag to admin/tool/ribbons as a submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,11 @@
 	path = admin/tool/ilioscategoryassignment
 	url = https://github.com/ilios/tool_ilioscategoryassignment.git
 	branch = MOODLE_404_STABLE
+[submodule "admin/tool/ribbons"]
+	path = admin/tool/ribbons
+	url = https://github.com/cwarwicker/moodle-tool_ribbons
+	branch = main
+	tag = v1.0.3
 [submodule "blocks/course_recent"]
 	path = blocks/course_recent
 	url = https://github.com/ucsf-education/moodle-block-course_recent
@@ -17,3 +22,4 @@
 [submodule "local/navbarhelpmenu"]
 	path = local/navbarhelpmenu
 	url = https://github.com/ucsf-education/moodle-local_navbarhelpmenu
+	branch = MOODLE_404_STABLE

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,8 +9,7 @@
 [submodule "admin/tool/ribbons"]
 	path = admin/tool/ribbons
 	url = https://github.com/cwarwicker/moodle-tool_ribbons
-	branch = main
-	tag = v1.0.3
+	branch = moodle_4.4
 [submodule "blocks/course_recent"]
 	path = blocks/course_recent
 	url = https://github.com/ucsf-education/moodle-block-course_recent


### PR DESCRIPTION
See GHA [here](https://github.com/ctam/moodle/actions/runs/10950324696).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208356848947589