### PR TITLE
Correct mix-up of the tag and branch information for admin/tool/ribbons in the .gitmodules file.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,8 @@
 [submodule "admin/tool/ribbons"]
 	path = admin/tool/ribbons
 	url = https://github.com/cwarwicker/moodle-tool_ribbons
-	branch = moodle_4.4
+	branch = main
+	tag = moodle_4.4
 [submodule "blocks/course_recent"]
 	path = blocks/course_recent
 	url = https://github.com/ucsf-education/moodle-block-course_recent


### PR DESCRIPTION
GHA passed [here](https://github.com/ctam/moodle/actions/runs/11078123759).