### PR TITLE
Added mod/checklist master 4.1.0.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -30,6 +30,11 @@
 	path = admin/tool/ucsfsomapi
 	url = https://github.com/ucsf-education/tool_ucsfsomapi.git
 	branch = MOODLE_404_STABLE
+[submodule "mod/checklist"]
+	path = mod/checklist
+	url = https://github.com/davosmith/moodle-checklist
+	branch = master
+	tag = 4.1.0.2
 [submodule "mod/customcert"]
 	path = mod/customcert
 	url = https://github.com/mdjnelson/moodle-mod_customcert


### PR DESCRIPTION
The UAT team needs to review this PR before getting the go-ahead to merge. It's currently failing the following behat scenario in my dev environment:

```
001 Scenario: A teacher can link to a course or a URL, but not both # /var/www/html/mod/checklist/tests/behat/course_link.feature:33
      And the "linkcourseid" "field" should be disabled             # /var/www/html/mod/checklist/tests/behat/course_link.feature:38
        The attribute "disabled" should be set but is not
```
