### PR TITLE
Adds the Moodle 4.4 version of the Ilios Enrollment plugin.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,3 +45,7 @@
 	url = https://github.com/PoetOS/moodle-mod_questionnaire
 	branch = MOODLE_404_STABLE
 	tag = v4.1.1
+[submodule "enrol/ilios"]
+	path = enrol/ilios
+	url = https://github.com/ilios/moodle-enrol-ilios
+	branch = MOODLE_404_STABLE


### PR DESCRIPTION
This comes with extensive test coverage, and a new Ilios API client implementation.

The former dependency on [`local_iliosapiclient`](https://github.com/ilios/local_iliosapiclient) has become obsolete and has been removed.

For reference on the upstream code changes, please see:
- https://github.com/ilios/moodle-enrol-ilios/pull/60
- https://github.com/ilios/moodle-enrol-ilios/pull/61
- https://github.com/ilios/moodle-enrol-ilios/pull/62

