### PR TITLE
Added the master branch of mod_diary

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -53,3 +53,7 @@
 	url = https://github.com/PoetOS/moodle-mod_questionnaire
 	branch = MOODLE_404_STABLE
 	tag = v4.1.1
+[submodule "mod/diary"]
+	path = mod/diary
+	url = https://github.com/drachels/moodle-mod_diary
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -67,11 +67,3 @@
 	url = https://github.com/PoetOS/moodle-mod_questionnaire
 	branch = MOODLE_404_STABLE
 	tag = v4.1.1
-[submodule "blocks/quickmail"]
-	path = blocks/quickmail
-	url = https://github.com/ucsf-education/moodle-block_quickmail
-	branch = UCSFCLE_404_STABLE
-[submodule "mod/diary"]
-	path = mod/diary
-	url = https://github.com/drachels/moodle-mod_diary
-	branch = master


### PR DESCRIPTION
The official v3.7.9 and v3.8.0 releases of mod_diary have (closed) issues pertaining to failed phpunit tests. Therefore, I added the master branch (as was done with our 403_STABLE branch), which is essentially a release candidate that has fixes for the known issues. The code maintainer of the Diary plugin has not given a date as to when the fixes in the release candidates will have an official release tag.

[Test successfully ran here](https://github.com/lbailey-ucsf/moodle/actions/runs/11557503258)