### PR TITLE
Adds the Moodle 4.4 version of the Ilios enrollment plugin.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,3 +85,7 @@
 	url = https://github.com/ncstate-delta/moodle-mod_zoom
 	branch = main
 	tag = v5.2.4
+[submodule "enrol/ilios"]
+	path = enrol/ilios
+	url = https://github.com/ilios/moodle-enrol-ilios
+	branch = MOODLE_404_STABLE


### PR DESCRIPTION
![98bbdq](https://github.com/user-attachments/assets/b266937d-f57f-48ae-b5ce-c5d6b9ed8ce1)


coming back around with this after [replacing test assertion in closures with history-middleware powered equivalent](https://github.com/ilios/moodle-enrol-ilios/pull/63).


refs https://github.com/ucsf-education/moodle/pull/89
refs https://github.com/ucsf-education/moodle/pull/96