### PR TITLE
Revert 'Run Tests on Pull Requests'

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,6 @@ on:
         description: Additional options to apply to PHPUnit
         required: false
         default: ''
-  pull_request:
 
 env:
   php: 8.3


### PR DESCRIPTION
Revert commit [967cdf2](https://github.com/ucsf-education/moodle/pull/97/commits/967cdf2c50165404d85d87f9b6e09762434182e3), Run Tests on Pull Requests, because this trigger does not work with private repos.
