### PR TITLE
Added format_topcoll MOODLE_404 V404.1.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,6 +14,10 @@
 	path = blocks/quickmail
 	url = https://github.com/ucsf-education/moodle-block_quickmail
 	branch = UCSFCLE_404_STABLE
+[submodule "course/format/topcoll"]
+	path = course/format/topcoll
+	url = https://github.com/gjbarnard/moodle-format_topcoll
+	branch = MOODLE_404
 [submodule "filter/ucsfezproxy"]
 	path = filter/ucsfezproxy
 	url = https://github.com/ucsf-education/moodle-filter_ucsfezproxy


### PR DESCRIPTION
Added the MOODLE_404 branch of format_topcoll tagged at V404.1.2.

[Passed phpUnit Tests](https://github.com/lbailey-ucsf/moodle/actions/runs/11616152645)

Plugin Behat Tests Results:
11 scenarios (11 passed)
111 steps (111 passed)
