### PR TITLE
Added availability_mobileapp UCSFCLE_403_STABLE

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,6 +6,10 @@
 	path = admin/tool/ilioscategoryassignment
 	url = https://github.com/ilios/tool_ilioscategoryassignment.git
 	branch = MOODLE_404_STABLE
+[submodule "availability/condition/mobileapp"]
+	path = availability/condition/mobileapp
+	url = https://github.com/ucsf-education/moodle-availability_mobileapp
+	branch = UCSFCLE_403_STABLE
 [submodule "blocks/attendance"]
 	path = blocks/attendance
 	url = https://github.com/danmarsden/moodle-block_attendance


### PR DESCRIPTION
The [official release of the Moodle Mobile app availability plugin ](https://github.com/moodlehq/moodle-availability_mobileapp) appears to have not been updated in the past 5 years. Due to [open issues](https://github.com/moodlehq/moodle-availability_mobileapp/issues) in the main branch of the official release, we opted to [fork](https://github.com/ucsf-education/moodle-availability_mobileapp), fix, and deploy our fork for a '4.0' release.

Our forked version [passed the phpUnt tests](https://github.com/lbailey-ucsf/moodle/actions/runs/11707142065). However, "There were 2 risky tests" reported due to deprecation. PR reviewers can decided whether or not we should address the 'risky tests' prior to integration into our `UCSFCLE_404_STABLE` branch.
