### PR TITLE
Updates mod_choicegroup to version 2024080801

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -124,7 +124,7 @@
 	path = mod/choicegroup
 	url = https://github.com/ndunand/moodle-mod_choicegroup
 	branch = master
-	tag = 2024080800
+	tag = 2024080801
 [submodule "mod/customcert"]
 	path = mod/customcert
 	url = https://github.com/markn86/moodle-mod_customcert


### PR DESCRIPTION
Update Group Choice plugin to version 2024080801 on M4.3 per [Asana T-1840](https://app.asana.com/0/187871667484662/1208719129044887/f)

[phpUnit Tests ran and passed](https://github.com/mirleu/moodle/actions/runs/11748857940).

