### PR TITLE
Updates mod_checklist to version 4.1.0.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -120,7 +120,7 @@
 	path = mod/checklist
 	url = https://github.com/davosmith/moodle-checklist
 	branch = master
-	tag = 4.1.0.2
+	tag = 4.1.0.3
 [submodule "mod/choicegroup"]
 	path = mod/choicegroup
 	url = https://github.com/ndunand/moodle-mod_choicegroup


### PR DESCRIPTION
Update Checklist plugin per [Asana T-1852](https://app.asana.com/0/1208136909461998/1208719129044897/f). Version release name is 4.1.0.3.

[phpUnit Tests ran and passed](https://github.com/mirleu/moodle/actions/runs/11862722278).