### PR TITLE
Updates block_checklist to version 3.4.3.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,7 +31,7 @@
 	path = blocks/checklist
 	url = https://github.com/davosmith/moodle-block_checklist
 	branch = master
-	tag = 3.4.3.1
+	tag = 3.4.3.2
 [submodule "blocks/course_recent"]
 	path = blocks/course_recent
 	url = https://github.com/ucsf-education/moodle-block-course_recent


### PR DESCRIPTION
Updates Checklist_Block plugin per [Asana T-1858](https://app.asana.com/0/1208136909461998/1208719129044899/f). Version release name 3.4.3.2.

[phpUnit Tests ran and passed](https://github.com/mirleu/moodle/actions/runs/11862953131).