### PR TITLE
T-1507/UCSFCLE 404/Add moodle-qtype_oumultiresponse plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -120,6 +120,11 @@
 	url = https://github.com/ncstate-delta/moodle-mod_zoom
 	branch = main
 	tag = v5.2.4
+[submodule "question/type/oumultiresponse"]
+	path = question/type/oumultiresponse
+	url = https://github.com/moodleou/moodle-qtype_oumultiresponse
+	branch = main
+	tag = v2.4
 [submodule "question/type/wordselect"]
 	path = question/type/wordselect
 	url = https://github.com/marcusgreen/moodle-qtype_wordselect

--- a/.gitmodules
+++ b/.gitmodules
@@ -124,7 +124,6 @@
 	path = question/type/oumultiresponse
 	url = https://github.com/moodleou/moodle-qtype_oumultiresponse
 	branch = main
-	tag = v2.4
 [submodule "question/type/wordselect"]
 	path = question/type/wordselect
 	url = https://github.com/marcusgreen/moodle-qtype_wordselect


### PR DESCRIPTION
- **Add moodle-qtype_oumultiresponse plugin with tag v2.4**
- **Update moodle-qtype_oumultiresponse plugin to use the tip of its main branch, instead of the v2.4 tag, to fix failing tests.**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208263209125037