### PR TITLE
T 1511/UCSFCLE 404/Add moodle plagiarism turnitin plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -112,6 +112,11 @@
 	url = https://github.com/ncstate-delta/moodle-mod_zoom
 	branch = main
 	tag = v5.2.4
+[submodule "plagiarism/turnitin"]
+	path = plagiarism/turnitin
+	url = https://github.com/turnitin/moodle-plagiarism_turnitin
+	branch = master
+	tag = v2024072401
 [submodule "question/type/knowledgecheck"]
 	path = question/type/knowledgecheck
 	url = https://github.com/ucsf-education/knowledgecheck.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -114,8 +114,8 @@
 	tag = v5.2.4
 [submodule "plagiarism/turnitin"]
 	path = plagiarism/turnitin
-	url = https://github.com/turnitin/moodle-plagiarism_turnitin
-	branch = master
+	url = https://github.com/ucsf-education/moodle-plagiarism_turnitin
+	branch = UCSFCLE_403_STABLE
 [submodule "question/type/knowledgecheck"]
 	path = question/type/knowledgecheck
 	url = https://github.com/ucsf-education/knowledgecheck.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -116,7 +116,6 @@
 	path = plagiarism/turnitin
 	url = https://github.com/turnitin/moodle-plagiarism_turnitin
 	branch = master
-	tag = v2024072401
 [submodule "question/type/knowledgecheck"]
 	path = question/type/knowledgecheck
 	url = https://github.com/ucsf-education/knowledgecheck.git


### PR DESCRIPTION
- **Add moodle-plagiarism_turnitin plugin with tag v2024072401.**
- **Update moodle-plagiarism_turnitin plugin to use the tip of its master branch, instead of the v2024072401 tag, to fix failing tests.**
- **Switch to use our forked repo, ucsf-education/moodle-plagiarism_turnitin to address failing tests in GHA.**


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208263209125039