### PR TITLE
Update mod_checklist to 4.1.0.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -83,7 +83,7 @@
 	path = mod/checklist
 	url = https://github.com/davosmith/moodle-checklist
 	branch = master
-	tag = 4.1.0.2
+	tag = 4.1.0.3
 [submodule "mod/choicegroup"]
 	path = mod/choicegroup
 	url = https://github.com/ndunand/moodle-mod_choicegroup


### PR DESCRIPTION
Update Checklist plugin to match version recently installed on UCSFCLE_403_STABLE.
