### PR TITLE
adds the Moodle 4.5 compatible version of the UCSF EZProxy filter plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -11,6 +11,10 @@
 	path = enrol/ucsfsis
 	url = https://github.com/ucsf-education/moodle-enrol-ucsfsis
 	branch = main
+[submodule "filter/ucsfezproxy"]
+	path = filter/ucsfezproxy
+	url = https://github.com/ucsf-education/moodle-filter_ucsfezproxy
+	branch = MOODLE_405_STABLE	
 [submodule "mod/checklist"]
 	path = mod/checklist
 	url = https://github.com/davosmith/moodle-checklist


### PR DESCRIPTION
for reference, please see https://github.com/ucsf-education/moodle-filter_ucsfezproxy/pull/23

no functional changes, but some shuffling around of existing code.