### PR TITLE
Added Custom Certificate plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,6 +33,11 @@
 	url = https://github.com/davosmith/moodle-checklist
 	branch = master
 	tag = 4.1.0.3
+[submodule "mod/customcert"]
+	path = mod/customcert
+	url = https://github.com/mdjnelson/moodle-mod_customcert
+	branch = MOODLE_404_STABLE
+	tag = v4.4.4
 [submodule "mod/oublog"]
 	path = mod/oublog
 	url = https://github.com/moodleou/moodle-mod_oublog
@@ -64,4 +69,3 @@
 	url = https://github.com/ucsf-education/moodle-theme-ucsf
 	branch = MOODLE_405_STABLE
 	tag = v4.5.1
-


### PR DESCRIPTION
Added the v4.4.4 of the plugin's MOODLE_404_STABLE. It's [documented as compatible with M4.5](https://moodle.org/plugins/mod_customcert/versions).