### PR TITLE
Update plagiarism_turnitin to v2025052901 in UCSFCLE_405

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -134,7 +134,7 @@
 	path = plagiarism/turnitin
 	url = https://github.com/turnitin/moodle-plagiarism_turnitin
 	branch = master
-	tag = v2025030501
+	tag = v2025052901
 [submodule "question/type/knowledgecheck"]
 	path = question/type/knowledgecheck
 	url = https://github.com/ucsf-education/knowledgecheck


### PR DESCRIPTION
Updated Plagiarism Turn It In Plugin to Release: v2025052901

Please note that issues [708 ](https://github.com/turnitin/moodle-plagiarism_turnitin/issues/708) and [790](https://github.com/turnitin/moodle-plagiarism_turnitin/issues/790) still exist when Behat tests are run.

This release has the following fixes per the plugin change log:

**Assignment Settings Error Fixed**

An issue was identified where when navigating the assignment settings an error message would appear. This has been resolved.

**Student Quiz Rubric Issue Fixed**

An issue was identified where the rubric would fail to open in the student quiz view. This has now been resolved.
Unlink/Relink Table Fixed

An issue was identified where trying to change the page on the unlink/relink users table would cause an infinite loading spinner. This has now been resolved.

**Stuck Submissions Fixed**

An issue was identified where submissions were getting stuck in the submission queue, which would eventually cause submissions to fail to be sent to turnitin. This has now been fixed.

[Assignment End Date Syncronization Issue Fixed](url)
An issue was identified where assignment end dates were sometimes not syncing correctly to Turnitin on Moodle versions 4.5+. This has now been fixed.
