### PR TITLE
Updates UCSFCLE_404_STABLE to use the Turn it in Tool Two v2025052901 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -118,8 +118,8 @@
 	tag = v5.0-r1
 [submodule "mod/turnitintooltwo"]
 	path = mod/turnitintooltwo
-	url = https://github.com/ucsf-education/moodle-mod_turnitintooltwo
-	branch = UCSFCLE_404_STABLE
+	url = https://github.com/turnitin/moodle-mod_turnitintooltwo
+	tag = v2025052901
 [submodule "mod/zoom"]
 	path = mod/zoom
 	url = https://github.com/ncstate-delta/moodle-mod_zoom


### PR DESCRIPTION
Updates UCSFCLE_404_STABLE to use the Turn it in Tool Two v2025052901 release instead of [our fork](https://github.com/ucsf-education/moodle-mod_turnitintooltwo) that tracks the develop branch.

This release contains the following fixes per the change log:

**Duplicate Calendar Events No Longer Created**

Previously modifying the assignment name could cause duplicate calendar events to be created. This will now no longer occur.
Icons Fixed

An issue was found where icons in the assignment view would not display correctly. This has now been fixed.

**Temporary Courses Now Deleted Correctly**

An issue was identified where sometimes courses with names made of a random string of letters would be created in Turnitin. These are now being deleted appropriately.

**Course Copy Anonymous Marking Issue Fixed**

An issue was identified where when copying a course, the end date would be copied across. If the assignment had anonymous marking enabled and the due date had passed, this would result in the assingment being unanonymized. This has now been fixed.