### PR TITLE
Add dependabot.yml to create PR for submodule update, update .gitmodules to point to the correct branches.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,8 @@ updates:
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "wednesday"
-      time: "10:00"
+      interval: "daily"
+      time: "5:00"
 
     # PRs will target this branch (the branch in your repo)
     target-branch: "UCSFCLE_405_STABLE"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "10:00"
+
+    # PRs will target this branch (the branch in your repo)
+    target-branch: "UCSFCLE_405_STABLE"
+
+    # Ignore specific submodules by name/pattern
+    ignore:
+      # Ignore by submodule path (common)
+      - dependency-name: "availability/condition/mobileapp"
+      - dependency-name: "lib/editor/tiny/plugins/fontcolor"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "5:00"
+      time: "05:00"
 
     # PRs will target this branch (the branch in your repo)
     target-branch: "UCSFCLE_405_STABLE"

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,7 +26,7 @@
 [submodule "blocks/attendance"]
 	path = blocks/attendance
 	url = https://github.com/danmarsden/moodle-block_attendance
-	branch = main
+	branch = MOODLE_405_STABLE
 [submodule "blocks/checklist"]
 	path = blocks/checklist
 	url = https://github.com/davosmith/moodle-block_checklist
@@ -48,7 +48,7 @@
 [submodule "course/format/topcoll"]
 	path = course/format/topcoll
 	url = https://github.com/gjbarnard/moodle-format_topcoll
-	branch = main
+	branch = MOODLE_405
 	tag = V405.1.4
 [submodule "enrol/ilios"]
 	path = enrol/ilios
@@ -128,11 +128,12 @@
 [submodule "mod/diary"]
 	path = mod/diary
 	url = https://github.com/drachels/moodle-mod_diary
-	branch = master
+	branch = MOODLE_400_STABLE
+	tag = v4.0.0
 [submodule "mod/oublog"]
 	path = mod/oublog
 	url = https://github.com/moodleou/moodle-mod_oublog
-	branch = MOODLE_404_STABLE
+	branch = MOODLE_405_STABLE
 [submodule "mod/questionnaire"]
 	path = mod/questionnaire
 	url = https://github.com/ucsf-education/moodle-mod_questionnaire


### PR DESCRIPTION
I have added a `.github/dependabot.yml` configuration to automate submodule updates.

* **Schedule:** Every Wednesday at 10:00 AM.
* **Logic:** Dependabot will track the `branch` specified in `.gitmodules` and open a PR whenever a submodule is behind the tip of that branch.

### Manual Exceptions

Most submodules conform to this workflow, but the following two currently require manual updates:

1. `availability/condition/mobileapp`
2. `lib/editor/tiny/plugins/fontcolor`

### Important Notes

* **Tags:** This method does not automatically update the `tag` attribute in `.gitmodules`. We will need to decide if we want to update these manually or omit them moving forward.
* **Verification:** While initial checks look good, please double-check the first few PRs generated by Dependabot to ensure they align with our requirements.
