### PR TITLE
switch to our fork of the collaped topics course format plugin.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,8 +47,8 @@
 	branch = UCSFCLE_405_STABLE
 [submodule "course/format/topcoll"]
 	path = course/format/topcoll
-	url = https://github.com/gjbarnard/moodle-format_topcoll
-	branch = MOODLE_405
+	url = https://github.com/ucsf-education/moodle-format_topcoll
+	branch = UCSFCLE_MOODLE_405
 	tag = V405.1.4
 [submodule "enrol/ilios"]
 	path = enrol/ilios


### PR DESCRIPTION
originally ticketed here:
https://github.com/gjbarnard/moodle-format_topcoll/issues/183

however, the plugin's maintainer has taken the issue tracker and pull request queue offline. so we're on our own with this, at least for the moment.

this PR re-integrates this plugin into the CLE codebase, this time from our fork of the repo and the M4.5 compatible branch containing the a11y fix that we put forth originally.

