### PR TITLE
bump up the limit on the maximum number of pull requests for version updates open at any time.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 
 updates:
+  - open-pull-request-limit: 10 # The limit on the number of maximum number of pull requests for version updates open at any time.
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:


### PR DESCRIPTION
saw this error message this morning when trying to [manually re-run dependabot](https://github.com/ucsf-education/moodle/network/updates/1277809664):

<img width="953" height="366" alt="image" src="https://github.com/user-attachments/assets/96d22475-3e03-4ede-be3f-d55240f79100" />


so i'm bumping the limit from the default 5 to 10.

for reference, please see: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-