### PR TITLE
MDL-88122 navigation: omit empty breadcrumb container in output.

### DIFF
--- a/lib/templates/navbar.mustache
+++ b/lib/templates/navbar.mustache
@@ -63,6 +63,7 @@
         ]
     }
 }}
+{{#get_items.0}}
 <nav aria-label="{{#str}}breadcrumb, access{{/str}}">
     <ol class="breadcrumb">{{!
         }}{{#get_items}}
@@ -87,3 +88,4 @@
         {{/get_items}}{{!
     }}</ol>
 </nav>
+{{/get_items.0}}

--- a/theme/boost/tests/behat/breadcrumb.feature
+++ b/theme/boost/tests/behat/breadcrumb.feature
@@ -44,7 +44,7 @@ Feature: Breadcrumbs navigation
     And I log in as "admin"
     When I follow "Preferences" in the user menu
     # There should be no breadcrumbs on this page.
-    Then ".breadcrumb-item" "css_element" should not exist in the ".breadcrumb" "css_element"
+    Then ".breadcrumb" "css_element" should not exist
 
   Scenario: Admin user sets the default home page to 'Dashboard' and navigates to its 'Preferences' and 'Private files' page
     Given the following config values are set as admin:
@@ -52,10 +52,10 @@ Feature: Breadcrumbs navigation
     And I log in as "admin"
     When I follow "Preferences" in the user menu
     # There should be no breadcrumbs on this page.
-    Then ".breadcrumb-item" "css_element" should not exist in the ".breadcrumb" "css_element"
+    Then ".breadcrumb" "css_element" should not exist
     And I follow "Private files" in the user menu
     # There should be no breadcrumbs on this page.
-    And ".breadcrumb-item" "css_element" should not exist in the ".breadcrumb" "css_element"
+    And ".breadcrumb" "css_element" should not exist
 
   Scenario: Admin user sets the default home page to 'User preference' and navigates to its 'Preferences' and 'Private files' page
     Given the following config values are set as admin:
@@ -63,10 +63,10 @@ Feature: Breadcrumbs navigation
     And I log in as "admin"
     When I follow "Preferences" in the user menu
     # There should be no breadcrumbs on this page.
-    Then ".breadcrumb-item" "css_element" should not exist in the ".breadcrumb" "css_element"
+    Then ".breadcrumb" "css_element" should not exist
     And I follow "Private files" in the user menu
     # There should be no breadcrumbs on this page.
-    And ".breadcrumb-item" "css_element" should not exist in the ".breadcrumb" "css_element"
+    And ".breadcrumb" "css_element" should not exist
 
   Scenario: Admin user sets the default home page to 'My courses' and navigates to its 'Preferences' and 'Private files' page
     Given the following config values are set as admin:
@@ -74,7 +74,7 @@ Feature: Breadcrumbs navigation
     And I log in as "admin"
     When I follow "Preferences" in the user menu
     # There should be no breadcrumbs on this page.
-    Then ".breadcrumb-item" "css_element" should not exist in the ".breadcrumb" "css_element"
+    Then ".breadcrumb" "css_element" should not exist
     And I follow "Private files" in the user menu
     # There should be no breadcrumbs on this page.
-    And ".breadcrumb-item" "css_element" should not exist in the ".breadcrumb" "css_element"
+    And ".breadcrumb" "css_element" should not exist


### PR DESCRIPTION
this changeset contains an a11y fix that has already been incorporated into the Moodle core, but won't ship in time for us to roll this out before the accessibility deadline.

so we'll have to patch this in out-of-band in order to meet our mandate.

for reference, please see https://moodle.atlassian.net/browse/MDL-88122 
and https://github.com/moodle/moodle/commit/857fa9d371252769ba8efad36cac045526affe32

thanks.