### PR TITLE
updates the Recent Courses block to v4.5.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -36,6 +36,7 @@
 	path = blocks/course_recent
 	url = https://github.com/ucsf-education/moodle-block-course_recent
 	branch = MOODLE_405_STABLE
+	tag = 4.5.1
 [submodule "blocks/massaction"]
 	path = blocks/massaction
 	url = https://github.com/Syxton/moodle-block_massaction


### PR DESCRIPTION
this update contains various coding style fixes and one accessibility fix. 

**ACHTUNG!** the accessibility fix changes the output of the block, please see https://github.com/ucsf-education/moodle-block-course_recent/pull/24 for details on that.

for general reference please check  the release notes for  v4.5.1 of this plugin.
https://github.com/ucsf-education/moodle-block-course_recent/releases/tag/v4.5.1