### PR TITLE
adds Recent Courses block for Moodle 5.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,8 @@
+[submodule "public/blocks/course_recent"]
+	path = public/blocks/course_recent
+	url = https://github.com/ucsf-education/moodle-block-course_recent
+	branch = MOODLE_501_STABLE
+	tag = v5.1.0
 [submodule "public/mod/attendance"]
 	path = public/mod/attendance
 	url = https://github.com/danmarsden/moodle-mod_attendance
@@ -7,3 +12,4 @@
 	url = https://github.com/ucsf-education/moodle-local_navbarhelpmenu
 	branch = MOODLE_501_STABLE
 	tag = v5.1.0
+


### PR DESCRIPTION
please see https://github.com/ucsf-education/moodle-block-course_recent/releases/tag/v5.1.0 for reference.
