### PR TITLE
Updates UCSF theme to version 4.5.4.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -183,4 +183,4 @@
 	path = theme/ucsf
 	url = https://github.com/ucsf-education/moodle-theme-ucsf
 	branch = MOODLE_405_STABLE
-	tag = v4.5.3
+	tag = v4.5.4


### PR DESCRIPTION
This fixes a minor bug in the switched-role course hint.

For reference, please see https://github.com/ucsf-education/moodle-theme-ucsf/releases/tag/v4.5.4