### PR TITLE
Adds M5.1 version of UCSF theme.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,6 +3,11 @@
 	url = https://github.com/ucsf-education/moodle-block-course_recent
 	branch = MOODLE_501_STABLE
 	tag = v5.1.0
+[submodule "public/local/navbarhelpmenu"]
+	path = public/local/navbarhelpmenu
+	url = https://github.com/ucsf-education/moodle-local_navbarhelpmenu
+	branch = MOODLE_501_STABLE
+	tag = v5.1.0
 [submodule "public/mod/attendance"]
 	path = public/mod/attendance
 	url = https://github.com/danmarsden/moodle-mod_attendance
@@ -12,8 +17,8 @@
 	url = https://github.com/drachels/moodle-mod_diary
 	branch = MOODLE_501_STABLE
 	tag = v5.0.0
-[submodule "public/local/navbarhelpmenu"]
-	path = public/local/navbarhelpmenu
-	url = https://github.com/ucsf-education/moodle-local_navbarhelpmenu
+[submodule "public/theme/ucsf"]
+	path = public/theme/ucsf
+	url = https://github.com/ucsf-education/moodle-theme-ucsf
 	branch = MOODLE_501_STABLE
 	tag = v5.1.0


### PR DESCRIPTION
For reference, please see https://github.com/ucsf-education/moodle-theme-ucsf/pull/212 and https://github.com/ucsf-education/moodle-theme-ucsf/releases/tag/v5.1.0.
