### PR TITLE
Add workflows to automate Moodle minor release upstream merges and PR creation

### DIFF
--- a/.github/workflows/merge-latest-upstream-tag-scheduled.yml
+++ b/.github/workflows/merge-latest-upstream-tag-scheduled.yml
@@ -1,0 +1,34 @@
+name: Scheduled Merge Latest Moodle Upstream Tag and Create Update PRs
+
+on:
+  schedule:
+    - cron: "0 6 * * *" # Every day at 6:00 AM
+      timezone: 'America/Los_Angeles'
+
+jobs:
+  sync:
+    name: Update ${{ matrix.target }} to latest upstream ${{ matrix.version }}.x release from ${{ matrix.upstream }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - version: "Moodle 4.5"
+            upstream: MOODLE_405_STABLE
+            target: UCSFCLE_405_STABLE
+            assignees: ctam
+            reviewers: ucsf-education/moodlecodereviewers
+
+          - version: "Moodle 5.1"
+            upstream: MOODLE_501_STABLE
+            target: UCSFCLE_501_STABLE
+            assignees: ctam
+            reviewers: ucsf-education/moodlecodereviewers
+
+    uses: ./.github/workflows/merge-latest-upstream-tag.yml
+
+    with:
+      upstream_branch: ${{ matrix.upstream }}
+      target_branch: ${{ matrix.target }}
+      assignees: ${{ matrix.assignees }}
+      reviewers: ${{ matrix.reviewers }}

--- a/.github/workflows/merge-latest-upstream-tag.yml
+++ b/.github/workflows/merge-latest-upstream-tag.yml
@@ -1,0 +1,297 @@
+name: Merge Latest Moodle Upstream Tag and Create Update PR (Reusable)
+
+on:
+  workflow_call:
+    inputs:
+      upstream_branch:
+        required: false
+        type: string
+      target_branch:
+        required: false
+        type: string
+      assignees:
+        required: false
+        type: string
+      reviewers:
+        required: false
+        type: string
+
+  workflow_dispatch:
+    inputs:
+      assignees:
+        description: "Assignee(s): Comma-separated GitHub usernames"
+        required: false
+        type: string
+
+      reviewers:
+        description: "Reviewer(s): Comma-separated GitHub usernames or team"
+        required: false
+        type: string
+
+jobs:
+  sync:
+    name: Merge upstream Moodle minor release
+    runs-on: ubuntu-latest
+
+    steps:
+      # ------------------------------------------------------------
+      # Derive branches (manual mode) OR use inputs (workflow_call)
+      # ------------------------------------------------------------
+      - name: Derive branches
+        id: derive
+        run: |
+          if [ -n "${{ inputs.target_branch }}" ]; then
+            echo "Using provided inputs (workflow_call)"
+            echo "target=${{ inputs.target_branch }}" >> $GITHUB_OUTPUT
+            echo "upstream=${{ inputs.upstream_branch }}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          BRANCH="${GITHUB_REF_NAME}"
+
+          echo "Detected branch: $BRANCH"
+
+          if [[ ! "$BRANCH" =~ ^UCSFCLE_([0-9]+) ]]; then
+            echo "❌ Invalid branch name"
+            echo "Branch must start with UCSFCLE_<numbers>"
+            echo "Example: UCSFCLE_405_STABLE"
+            exit 1
+          fi
+
+          VERSION="${BASH_REMATCH[1]}"
+          UPSTREAM="MOODLE_${VERSION}_STABLE"
+
+          echo "Derived target branch: $BRANCH"
+          echo "Derived upstream branch: $UPSTREAM"
+
+          echo "target=$BRANCH" >> $GITHUB_OUTPUT
+          echo "upstream=$UPSTREAM" >> $GITHUB_OUTPUT
+
+      # ------------------------------------------------------------
+      # Export env vars AFTER derive step
+      # ------------------------------------------------------------
+      - name: Set environment variables
+        run: |
+          echo "TARGET_BRANCH=${{ steps.derive.outputs.target }}" >> $GITHUB_ENV
+          echo "UPSTREAM_BRANCH=${{ steps.derive.outputs.upstream }}" >> $GITHUB_ENV
+
+      # ------------------------------------------------------------
+      # Debug context
+      # ------------------------------------------------------------
+      - name: Debug inputs
+        run: |
+          echo "TARGET_BRANCH=$TARGET_BRANCH"
+          echo "UPSTREAM_BRANCH=$UPSTREAM_BRANCH"
+          echo "GITHUB_REF_NAME=$GITHUB_REF_NAME"
+          echo "GITHUB_EVENT_NAME=$GITHUB_EVENT_NAME"
+
+      # ------------------------------------------------------------
+      # Checkout target branch
+      # ------------------------------------------------------------
+      - name: Checkout target branch
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          ref: ${{ env.TARGET_BRANCH }}
+
+      # ------------------------------------------------------------
+      # Git identity for commits
+      # ------------------------------------------------------------
+      - name: Configure git identity
+        run: |
+          # GitHub Actions bot identity
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      # ------------------------------------------------------------
+      # Add upstream Moodle repo
+      # ------------------------------------------------------------
+      - name: Add upstream + fetch
+        run: |
+          git remote add upstream https://github.com/moodle/moodle.git || true
+          git fetch upstream --tags
+          git fetch upstream "+refs/heads/*:refs/remotes/upstream/*"
+
+      # ------------------------------------------------------------
+      # Derive version prefix from upstream branch
+      # ------------------------------------------------------------
+      - name: Derive version prefix
+        id: version
+        run: |
+          RAW=$(echo "$UPSTREAM_BRANCH" | sed -E 's/MOODLE_([0-9]+)_STABLE/\1/')
+          MAJOR=$(echo "$RAW" | cut -c1)
+          MINOR=$(echo "$RAW" | cut -c2-3 | sed 's/^0//')
+
+          PREFIX="v${MAJOR}.${MINOR}."
+          echo "prefix=$PREFIX" >> $GITHUB_OUTPUT
+          echo "Using tag prefix: $PREFIX"
+
+      # ------------------------------------------------------------
+      # Find latest matching upstream tag
+      # ------------------------------------------------------------
+      - name: Find latest valid tag
+        id: latest_tag
+        run: |
+          PREFIX=${{ steps.version.outputs.prefix }}
+
+          TAG=$(git tag \
+            --list "${PREFIX}*" \
+            --merged upstream/$UPSTREAM_BRANCH \
+            --sort=-v:refname | head -n 1)
+
+          if [ -z "$TAG" ]; then
+            echo "No matching tag found for prefix $PREFIX"
+            exit 1
+          fi
+
+          echo "latest_tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Found latest tag: $TAG"
+
+      # ------------------------------------------------------------
+      # Verify tag is actually part of upstream branch
+      # ------------------------------------------------------------
+      - name: Verify tag ancestry
+        run: |
+          TAG=${{ steps.latest_tag.outputs.latest_tag }}
+          git merge-base --is-ancestor "$TAG" "upstream/$UPSTREAM_BRANCH"
+
+      # ------------------------------------------------------------
+      # Check if already merged into target branch
+      # ------------------------------------------------------------
+      - name: Check if already merged
+        id: check
+        run: |
+          git checkout $TARGET_BRANCH
+
+          TAG=${{ steps.latest_tag.outputs.latest_tag }}
+
+          if git merge-base --is-ancestor "$TAG" HEAD; then
+            echo "already_merged=true" >> $GITHUB_OUTPUT
+            echo "Already up to date"
+          else
+            echo "already_merged=false" >> $GITHUB_OUTPUT
+          fi
+
+      # ------------------------------------------------------------
+      # Get current version in target branch
+      # ------------------------------------------------------------
+      - name: Get current merged version
+        id: current_tag
+        run: |
+          PREFIX=${{ steps.version.outputs.prefix }}
+
+          CURRENT=$(git tag \
+            --merged HEAD \
+            --list "${PREFIX}*" \
+            --sort=-v:refname | head -n 1)
+
+          echo "current_tag=${CURRENT:-none}" >> $GITHUB_OUTPUT
+
+      # ------------------------------------------------------------
+      # Clean working tree before merge
+      # ------------------------------------------------------------
+      - name: Reset working tree
+        run: |
+          git checkout $TARGET_BRANCH
+          git reset --hard
+          git clean -fd
+
+      # ------------------------------------------------------------
+      # Merge upstream tag
+      # ------------------------------------------------------------
+      - name: Merge upstream tag
+        if: steps.check.outputs.already_merged == 'false'
+        id: merge
+        run: |
+          TAG=${{ steps.latest_tag.outputs.latest_tag }}
+
+          git merge "$TAG" --no-edit || {
+            echo "Merge conflict detected"
+            exit 1
+          }
+
+          # Detect workflow changes introduced by upstream
+          if git diff --name-only ORIG_HEAD HEAD | grep -q "^.github/workflows/"; then
+            echo "workflow_changed=true" >> $GITHUB_OUTPUT
+
+            # Revert workflow changes to avoid GitHub permission issues
+            git checkout ORIG_HEAD -- .github/workflows
+            git add .github/workflows
+            git commit -m "Revert upstream workflow changes"
+          else
+            echo "workflow_changed=false" >> $GITHUB_OUTPUT
+          fi
+
+      # ------------------------------------------------------------
+      # Build PR warning message
+      # ------------------------------------------------------------
+      - name: Build workflow warning message
+        id: workflow_msg
+        run: |
+          if [ "${{ steps.merge.outputs.workflow_changed }}" = "true" ]; then
+            {
+              echo "message<<EOF"
+              echo "---"
+              echo "⚠️ **Workflow changes detected and were not applied**"
+              echo ""
+              echo "Upstream changes to \`.github/workflows/\` were NOT merged."
+              echo ""
+              echo "Review changes:"
+              echo "\`\`\`bash"
+              echo "git fetch upstream"
+              echo "git diff ${{ env.TARGET_BRANCH }} ${{ steps.latest_tag.outputs.latest_tag }} -- .github/workflows"
+              echo "\`\`\`"
+              echo ""
+              echo "Merge manually if needed:"
+              echo "\`\`\`bash"
+              echo "git checkout ${{ env.TARGET_BRANCH }}"
+              echo "git merge ${{ steps.latest_tag.outputs.latest_tag }}"
+              echo "\`\`\`"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+          else
+            echo "message=" >> $GITHUB_OUTPUT
+          fi
+
+      # ------------------------------------------------------------
+      # Compute PR labels
+      # ------------------------------------------------------------
+      - name: Set labels
+        id: labels
+        run: |
+          if [ "${{ steps.merge.outputs.workflow_changed }}" = "true" ]; then
+            echo "labels=moodle-core,upstream-workflow-change" >> $GITHUB_OUTPUT
+          else
+            echo "labels=moodle-core" >> $GITHUB_OUTPUT
+          fi
+
+      # ------------------------------------------------------------
+      # Create Pull Request
+      # ------------------------------------------------------------
+      - name: Create Pull Request
+        if: steps.check.outputs.already_merged == 'false'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: Merge-Moodle-${{ steps.latest_tag.outputs.latest_tag }}
+          base: ${{ env.TARGET_BRANCH }}
+          add-paths: .
+          title: >
+            Update to Moodle ${{ steps.latest_tag.outputs.latest_tag }}
+            from ${{ steps.current_tag.outputs.current_tag }}
+
+          body: |
+            Automated Moodle upgrade
+
+            **From:** `${{ steps.current_tag.outputs.current_tag }}`
+            **To:** `${{ steps.latest_tag.outputs.latest_tag }}`
+            **Upstream branch:** `${{ env.UPSTREAM_BRANCH }}`
+
+            ${{ steps.workflow_msg.outputs.message }}
+
+          commit-message: |
+            Update Moodle to ${{ steps.latest_tag.outputs.latest_tag }}
+
+          assignees: ${{ inputs.assignees }}
+          reviewers: ${{ inputs.reviewers }}
+
+          labels: ${{ steps.labels.outputs.labels }}


### PR DESCRIPTION
* Introduce reusable workflow to detect latest upstream Moodle tag and merge into target branch
* Support both manual (`workflow_dispatch`) and reusable (`workflow_call`) execution
* Auto-derive upstream/target branches or accept explicit inputs
* Validate and select latest valid upstream tag by version prefix
* Skip if already merged into target branch
* Handle merge conflicts and clean working tree before merge
* Detect and revert upstream `.github/workflows` changes to avoid permission issues
* Generate PR with version diff, labels, and optional assignees/reviewers
* Add scheduled workflow (daily 6 AM PT) to update multiple Moodle versions via matrix strategy
