### PR TITLE
updates the Ilios category assignment plugin to version 5.1.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,7 @@
 	path = public/admin/tool/ilioscategoryassignment
 	url = https://github.com/ilios/tool_ilioscategoryassignment
 	branch = MOODLE_501_STABLE
-	tag = v5.1.0
+	tag = v5.1.1
 [submodule "public/blocks/checklist"]
 	path = public/blocks/checklist
 	url = https://github.com/davosmith/moodle-block_checklist


### PR DESCRIPTION
for reference, please see https://github.com/ilios/tool_ilioscategoryassignment/releases/tag/v5.5.1