### PR TITLE
adds the Moodle 5.1 version of the UCSF SOM API plugin.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,6 +8,11 @@
 	url = https://github.com/ilios/tool_ilioscategoryassignment
 	branch = MOODLE_501_STABLE
 	tag = v5.1.1
+[submodule "public/admin/tool/ucsfsomapi"]
+	path = public/admin/tool/ucsfsomapi
+	url = https://github.com/ucsf-education/tool_ucsfsomapi
+	branch = MOODLE_501_STABLE
+	tag = v5.1.0
 [submodule "public/blocks/attendance"]
 	path = public/blocks/attendance
 	url = https://github.com/danmarsden/moodle-block_attendance


### PR DESCRIPTION
please see https://github.com/ucsf-education/tool_ucsfsomapi/releases/tag/v5.1.0 for reference.
