### PR TITLE
Moodle 4.5: Skip failing PHPUnit tests by excluding 'plugin_checks'

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -130,7 +130,9 @@ jobs:
         env:
           dbtype: ${{ matrix.db }}
           phpunit_options: ${{ secrets.phpunit_options }}
-        run: vendor/bin/phpunit $phpunit_options ${{ inputs.phpunit_extra_options }}
+        # Call phpunit with '--exclude-group plugin_checks' to skip failing tests for now.
+        # (See [Issue #371](https://github.com/ucsf-education/moodle/issues/371).)
+        run: vendor/bin/phpunit $phpunit_options ${{ inputs.phpunit_extra_options }} --exclude-group plugin_checks
 
       - name: Git status
         run: git status


### PR DESCRIPTION
Exclude 'plugin_checks' group from PHPUnit tests to skip failing tests temporarily.

