### PR TITLE
Update submodule branch for massaction to MOODLE_501_STABLE

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,7 +42,7 @@
 [submodule "public/blocks/massaction"]
 	path = public/blocks/massaction
 	url = https://github.com/Syxton/moodle-block_massaction
-	branch = master
+	branch = MOODLE_501_STABLE
 	tag = 7.5.1
 [submodule "public/blocks/quickmail"]
 	path = public/blocks/quickmail


### PR DESCRIPTION
The developer has finally brought MOODLE_501_STABLE up-to-date, see https://github.com/Syxton/moodle-block_massaction/issues/146#issuecomment-4514929354

